### PR TITLE
itunes-connectのinputのtitle指定を部分一致検索に変更

### DIFF
--- a/lib/plugin/in/itunesconnect.js
+++ b/lib/plugin/in/itunesconnect.js
@@ -22,7 +22,7 @@ iTunesConnect.load = function(args, next) {
     for (i=0; i<result.length; i++) {
       application = result[i];
 
-      if (application.title == args.unit.title) {
+      if (application.title.indexOf(args.unit.title) != -1) {
         passedUnit.push(application.units);
       }
     }


### PR DESCRIPTION
evac便利そう！

`application.title`の後方に半角スペースが入っていて判定でスルーしてしまったので (以下、console.log結果参照) 、検索しやすいよう部分一致に変更しました。

```
application.title = [triph - まちの音声ガイド ]
args.unit.title = [triph - まちの音声ガイド]
```
