### PR TITLE
標準入力プラグイン追加

### DIFF
--- a/lib/plugin/in/stdin.js
+++ b/lib/plugin/in/stdin.js
@@ -1,0 +1,8 @@
+var stdin = {};
+
+stdin.load = function(args, next) {
+  var stdinWord = require("fs").readFileSync("/dev/stdin", "utf8");
+  next(false, [stdinWord]);
+}
+
+module.exports = stdin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evac",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Node.js based simple aggregator. - http://bit.ly/evac_aggregator",
   "main": "index.js",
   "scripts": {

--- a/test/plugin/in/stdin_test.js
+++ b/test/plugin/in/stdin_test.js
@@ -1,0 +1,8 @@
+var stdin = require('../../../lib/plugin/in/stdin.js');
+describe('input plugin: stdin', function(){
+  it.skip('should received STDIN.', function(done){
+    stdin.load({}, function(error, output){
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### 解決したいこと
- ```echo "hoge" | evac foo.js``` の様な形で標準入力をevacの入力として扱える様なプラグインを新設します。