### PR TITLE
YAMLで定義されたレシピを読み込んだ際にプラグイン設定が無い場合の不具合修正

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -34,52 +34,38 @@ var parseRecipeFile = function(path) {
       process.exit(1);
     }
 
-    config.load(function (err, conf) {
+    core.parseRecipeJson(config, function(err, message){
       if (err) {
-        logger.error('Failed to load configuration from ' + path);
+        logger.error(message + " plugin - raise error.");
+        logger.error(err);
         process.exit(1);
       }
-
-      core.parseRecipeJson(conf, function(err, message){
-        if (err) {
-          logger.error(message + " plugin - raise error.");
-          logger.error(err);
-          process.exit(1);
-        }
-      });
     });
   });
 };
 
 var parseCronFile = function(path) {
-  util.parseSettingFile(path, function(err, config){
+  util.parseSettingFile(path, function(err, cronConfig){
     if (err) {
       logger.error("Error parsing your cron configuration file.");
       process.exit(1);
     }
 
-    config.load(function (err, cronConfig) {
-      if (err) {
-        logger.error('Failed to load configuration from ' + path);
-        process.exit(1);
+    var jobs = [];
+
+    for(var config in cronConfig) {
+      var oneConfig = cronConfig[config];
+
+      for (var schedule in oneConfig) {
+        var job = new CronJob({
+          cronTime: schedule,
+          onTick: function() {
+            parseRecipeFile(oneConfig[schedule]);
+          },
+          start: true
+        });
       }
-
-      var jobs = [];
-
-      for(var config in cronConfig) {
-        var oneConfig = cronConfig[config];
-
-        for (var schedule in oneConfig) {
-          var job = new CronJob({
-            cronTime: schedule,
-            onTick: function() {
-              parseRecipeFile(oneConfig[schedule]);
-            },
-            start: true
-          });
-        }
-      }
-    });
+    }
   });
 };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -16,7 +16,18 @@ evacUtil.parseSettingFile = function(filePath, callback){
 
   try {
     config.use('file', settings);
-    callback(false, config);
+    config.load(function (err, conf) {
+      var pluginType = ['out', 'filter', 'in'];
+      pluginType.forEach(function(type) {
+        for (var plugin in conf[type]) {
+          if (conf[type][plugin] == null) {
+            conf[type][plugin] = {};
+          }
+        }
+      })
+
+      callback(false, conf);
+    });
   } catch(e) {
     callback(e, null);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evac",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Node.js based simple aggregator. - http://bit.ly/evac_aggregator",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/recipe/sample.json
+++ b/test/fixtures/recipe/sample.json
@@ -1,0 +1,13 @@
+{
+  "in": {
+    "staticWord": {
+      "text": "test word."
+    }
+  },
+  "filter": {
+    "through": {}
+  },
+  "out": {
+    "stdout": {}
+  }
+}

--- a/test/fixtures/recipe/sample.yaml
+++ b/test/fixtures/recipe/sample.yaml
@@ -1,0 +1,8 @@
+in:
+  staticWord:
+    text: "test word."
+filter:
+  through:
+out:
+  stdout:
+

--- a/test/task.js
+++ b/test/task.js
@@ -6,6 +6,7 @@ describe('evac tasks', function(){
     it('should be parse recipe file. (JSON format)', function(done){
       util.parseSettingFile(__dirname + '/fixtures/recipe/sample.json', function(err, config){
         err.should.be.false;
+        config.out.stdout.should.be.a('object');
         done();
       });
     });
@@ -13,6 +14,7 @@ describe('evac tasks', function(){
     it('should be parse recipe file. (YAML format)', function(done){
       util.parseSettingFile(__dirname + '/fixtures/recipe/sample.yaml', function(err, config){
         err.should.be.false;
+        config.out.stdout.should.be.a('object');
         done();
       });
     });


### PR DESCRIPTION
### 解決したいこと
以下の様なYAMLファイルで定義されたレシピがあった場合、各プラグインの設定が ```null``` 扱いされるため、オブジェクトと解釈される様に修正します。

```yaml
in:
  staticWord:
    text: "test word."
filter:
  through:
out:
  stdout:
```