### PR TITLE
Add slack output plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ An execution result is displayed in detail.
 - shell
 - yo
 - pushbullet
+- slack
 
 ## Sample
 

--- a/lib/plugin/out/slack.js
+++ b/lib/plugin/out/slack.js
@@ -16,6 +16,7 @@ slack.output = function(args, word, next) {
     text: slackPushWord
   };
 
+  // call API
   var options = {
     uri: args.url,
     headers: { 'Content-Type': 'application/json' },

--- a/lib/plugin/out/slack.js
+++ b/lib/plugin/out/slack.js
@@ -12,7 +12,7 @@ slack.output = function(args, word, next) {
     if(!error && response.statusCode == 200) {
       next(false, body);
     } else {
-      next(error, "Slack incomming API call failed.");
+      next(true, "Slack incomming API call failed.");
     }
   });
 }

--- a/lib/plugin/out/slack.js
+++ b/lib/plugin/out/slack.js
@@ -1,0 +1,20 @@
+var request = require('request');
+var slack = {};
+
+slack.output = function(args, word, next) {
+  var options = {
+    uri: args.url,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: word })
+  };
+
+  request.post(options, function(error, response, body) {
+    if(!error && response.statusCode == 200) {
+      next(false, body);
+    } else {
+      next(error, "Slack incomming API call failed.");
+    }
+  });
+}
+
+module.exports = slack;

--- a/lib/plugin/out/slack.js
+++ b/lib/plugin/out/slack.js
@@ -11,10 +11,15 @@ slack.output = function(args, word, next) {
     slackPushWord = word;
   }
 
+  // slack incoming Webhook settings.
+  var slackSetting = {
+    text: slackPushWord
+  };
+
   var options = {
     uri: args.url,
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text: slackPushWord})
+    body: JSON.stringify(slackSetting)
   };
 
   request.post(options, function(error, response, body) {

--- a/lib/plugin/out/slack.js
+++ b/lib/plugin/out/slack.js
@@ -2,15 +2,24 @@ var request = require('request');
 var slack = {};
 
 slack.output = function(args, word, next) {
+  // format
+  var slackPushWord;
+
+  if (args.format) {
+    slackPushWord = args.format.replace("__word__", word);
+  } else {
+    slackPushWord = word;
+  }
+
   var options = {
     uri: args.url,
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text: word })
+    body: JSON.stringify({ text: slackPushWord})
   };
 
   request.post(options, function(error, response, body) {
     if(!error && response.statusCode == 200) {
-      next(false, body);
+      next(false, slackPushWord);
     } else {
       next(true, "Slack incomming API call failed.");
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evac",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Node.js based simple aggregator. - http://bit.ly/evac_aggregator",
   "main": "index.js",
   "scripts": {

--- a/test/plugin/out/slack_test.js
+++ b/test/plugin/out/slack_test.js
@@ -1,0 +1,34 @@
+var slack = require('../../../lib/plugin/out/slack.js'),
+    nock = require('nock');
+
+describe('output plugin: slack', function(){
+  var mockUrl = "https://hooks.slack.com/services/1/2/3";
+
+  it('should be successful call to slack incomming API.', function(done){
+    nock(mockUrl).post('/services/1/2/3').reply(200);
+
+    var args = {
+      "url": mockUrl,
+      "text": "Hi"
+    };
+
+    slack.output(args, "test", function(err, output){
+      err.should.be.false;
+      done();
+    });
+  });
+
+  it('should be fail call to slack incoming API.', function(done){
+    nock(mockUrl).post('/services/1/2/3').reply(500);
+
+    var args = {
+      "url": mockUrl,
+      "text1": "Hi"
+    };
+
+    slack.output(args, "test", function(err, output){
+      err.should.be.true;
+      done();
+    });
+  });
+});

--- a/test/plugin/out/slack_test.js
+++ b/test/plugin/out/slack_test.js
@@ -31,4 +31,22 @@ describe('output plugin: slack', function(){
       done();
     });
   });
+
+  it('should be format text.', function(done){
+    nock(mockUrl).post('/services/1/2/3').reply(200);
+
+    var args = {
+      "url": mockUrl,
+      "text": "world",
+      "format": "Hello __word__"
+    };
+
+    slack.output(args, "world", function(err, output){
+      err.should.be.false;
+      output.should.be.equal("Hello world");
+      done();
+    });
+  });
+
+
 });


### PR DESCRIPTION
### 解決したいこと
SlackのIncoming WebHooksを利用してevacの処理内容を通知できる様にします。
レシピは以下の様なイメージです。

```yaml
in:
  staticWord:
    text: Hello, slack! <http://www.remp.jp>
out:
  slack:
    url: https://hooks.slack.com/services/T02*****/B03******/cZ98******
```

