### PR TITLE
Google analyticsプラグイン改良

### DIFF
--- a/lib/plugin/in/googleanalytics.js
+++ b/lib/plugin/in/googleanalytics.js
@@ -8,7 +8,7 @@ googleAnalytics.load = function(args, next) {
 
   // Setting before a fixed period of time
   if (args.timeago) {
-    args['startDate'] = args['endDate'] = moment().add(args.timeago.unit, -1 * args.timeago.ago).format("YYYY-MM-DD");
+    args['startDate'] = args['endDate'] = moment().add(-1 * args.timeago.ago, args.timeago.period).format("YYYY-MM-DD");
   }
 
   gaAnalytics(args, function(err, res) { 

--- a/lib/plugin/in/googleanalytics.js
+++ b/lib/plugin/in/googleanalytics.js
@@ -6,6 +6,11 @@ var googleAnalytics = {};
 googleAnalytics.load = function(args, next) {
   var outputs = [];
 
+  // Setting before a fixed period of time
+  if (args.timeago) {
+    args['startDate'] = args['endDate'] = moment().add(args.timeago.unit, -1 * args.timeago.ago).format("YYYY-MM-DD");
+  }
+
   gaAnalytics(args, function(err, res) { 
     if(err) {
       next(error, "google analytics error.");

--- a/lib/plugin/in/googleanalytics.js
+++ b/lib/plugin/in/googleanalytics.js
@@ -1,4 +1,5 @@
-var gaAnalytics = require("ga-analytics");
+var gaAnalytics = require("ga-analytics"),
+    moment = require("moment");
 
 var googleAnalytics = {};
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "js-yaml": "^3.2.6",
     "jsonschema": "^1.0.0",
     "mkdirp": "^0.5.0",
+    "moment": "^2.9.0",
     "mysql": "^2.5.2",
     "nconf": "^0.6.9",
     "node-notifier": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evac",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Node.js based simple aggregator. - http://bit.ly/evac_aggregator",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### 解決したいこと
- 現状Google analyticsプラグインを利用して入力の値を取得する場合、開始日時・終了日時を指定する必要がありましたが、これを相対的に指定できる様にします。
- 指定は ```timeago``` というプロパティで指定できるものとします。

```json
{
  "in": {
    "googleanalytics": {
      "metrics": "ga:pageviews",
      "clientId": "*******.apps.googleusercontent.com",
      "serviceEmail": "******@developer.gserviceaccount.com",
      "key": "/foo/bar/key.pem",
      "ids": "ga:********",
      "timeago": {
        "period": "days",
        "ago": 1
      }
    }
  },
  "out": {
    "stdout": {}
  }
}
```
