### PR TITLE
request filter plugin 追加

### DIFF
--- a/lib/plugin/filter/request.js
+++ b/lib/plugin/filter/request.js
@@ -2,7 +2,14 @@ var client = require('request');
 var request = {};
 
 request.filter = function(args, word, next) {
-  client(word, function(err, response, body) {
+  var options = {
+    url: word,
+    headers: {
+      'User-Agent': 'evac aggregator'
+    }
+  };
+
+  client(options, function(err, response, body) {
     if (!err) {
       var output = "",
           code = response.statusCode;

--- a/lib/plugin/filter/request.js
+++ b/lib/plugin/filter/request.js
@@ -1,0 +1,23 @@
+var client = require('request');
+var request = {};
+
+request.filter = function(args, word, next) {
+  client(word, function(err, response, body) {
+    if (!err) {
+      var output = "",
+          code = response.statusCode;
+
+      if (args.format) {
+        output = args.format.replace("__code__", code).replace("__body__", body);
+      } else {
+        output = body;
+      }
+
+      next(false, output);
+    } else {
+      next(true, "ERROR:" + err);
+    }
+  });
+}
+
+module.exports = request;

--- a/test/plugin/filter/request_test.js
+++ b/test/plugin/filter/request_test.js
@@ -1,0 +1,35 @@
+var request = require('../../../lib/plugin/filter/request.js'),
+    nock = require('nock');
+
+describe('filter plugin: request', function(){
+  var mockUrl = "http://test-request.com/";
+
+  beforeEach(function() {
+    var testBody = "Hello, world.\n";
+    nock(mockUrl).get('/').reply(200, testBody);
+  });
+
+  it('should be able to read from body.', function(done){
+    request.filter({}, mockUrl, function(err, word) {
+      err.should.be.false;
+      word.should.equal("Hello, world.\n");
+      done();
+    });
+  });
+
+  it('should be able to read from status code.', function(done){
+    request.filter({format: "__code__"}, mockUrl, function(err, word) {
+      err.should.be.false;
+      word.should.equal("200");
+      done();
+    });
+  });
+
+  it('should be able to read from body & status code with format strings.', function(done){
+    request.filter({format: "__body__\n__code__"}, mockUrl, function(err, word) {
+      err.should.be.false;
+      word.should.equal("Hello, world.\n\n200");
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### 解決したいこと
- 入力をURL文字列としてHTTPリクエストを発行し、得られたステータスコード及び、BODY文字列を出力として変換するrequest filterプラグインを追加します。

### 例
入力URLを元にHTTPリクエストを発行し得られたBODY文字列を出力

```yaml
filter:
  request:
    log: __body__
```
