### PR TITLE
Add screen shot output plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules
 *.swp
 recipe/
 tmp/*
+test/tmp/*.png

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ An execution result is displayed in detail.
 - yo
 - pushbullet
 - slack
+- screenshot
 
 ## Sample
 

--- a/lib/plugin/out/screenshot.js
+++ b/lib/plugin/out/screenshot.js
@@ -3,10 +3,16 @@ var webshot = require('webshot'),
     url = require('url');
 
 screenshot.output = function(args, word, next) {
-  var fileName = url.parse(word).hostname + ".png";
+  var targetUrl = word;
+
+  if (url.parse(targetUrl).hostname === null) {
+    targetUrl = "http://" + targetUrl;
+  }
+
+  var fileName = url.parse(targetUrl).hostname + ".png";
   var filePath = args.path + "/" + fileName;
 
-  webshot(word, filePath, function(err){
+  webshot(targetUrl, filePath, function(err){
     if (err) {
       next(true, err);
     } else {

--- a/lib/plugin/out/screenshot.js
+++ b/lib/plugin/out/screenshot.js
@@ -1,0 +1,18 @@
+var screenshot = {};
+var webshot = require('webshot'),
+    url = require('url');
+
+screenshot.output = function(args, word, next) {
+  var fileName = url.parse(word).hostname + ".png";
+  var filePath = args.path + "/" + fileName;
+
+  webshot(word, filePath, function(err){
+    if (err) {
+      next(true, err);
+    } else {
+      next(false, "Save screen shot: " + filePath);
+    }
+  });
+}
+
+module.exports = screenshot;

--- a/lib/plugin/out/screenshot.js
+++ b/lib/plugin/out/screenshot.js
@@ -14,7 +14,7 @@ screenshot.output = function(args, word, next) {
 
   webshot(targetUrl, filePath, function(err){
     if (err) {
-      next(true, err);
+      next(false, "HTTP Error:" + targetUrl + " Message:" + err);
     } else {
       next(false, "Save screen shot: " + filePath);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evac",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Node.js based simple aggregator. - http://bit.ly/evac_aggregator",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "nodemailer": "^1.3.0",
     "pushbullet": "^1.4.2",
     "request": "^2.44.0",
+    "webshot": "^0.15.4",
     "winston": "^0.8.1"
   },
   "devDependencies": {

--- a/test/plugin/out/screenshot_test.js
+++ b/test/plugin/out/screenshot_test.js
@@ -1,0 +1,29 @@
+var screenshot = require('../../../lib/plugin/out/screenshot.js');
+var fs = require('fs');
+
+describe('output plugin: screenshot', function(){
+  this.timeout(10000);
+
+  var url = "http://www.yahoo.co.jp";
+  var args = {
+    "path": process.cwd() + "/test/tmp"
+  };
+
+  beforeEach(function(done) {
+    var screenshotImage = args.path + "/www.yahoo.co.jp.png";
+
+    fs.exists(screenshotImage, function(exists) {
+      if (exists) {
+        fs.unlinkSync(screenshotImage);
+      }
+      done();
+    });
+  });
+
+  it('should be take a screenshot.', function(done){
+    screenshot.output(args, url, function(err, output) {
+      err.should.be.false;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### 解決したいこと
- input, filter の出力として渡された文字列(URL)に対してスクリーンショットを取得するプラグインを作成します。

### 例
```/foo/bar/text.txt``` に1行毎にURLが記載されている場合、それぞれのページのスクリーンショットを ```/home/hideack/screenshots``` に保存します。

```yaml
in:
  textfile:
    name: /foo/bar/text.txt
out:
  screenshot:
    path: /home/hideack/screenshots
```
