### PR TITLE
Add battery input plugin

### DIFF
--- a/lib/plugin/in/battery.js
+++ b/lib/plugin/in/battery.js
@@ -1,0 +1,16 @@
+var batteryLevel = require('battery-level');
+
+var battery = {};
+
+battery.load = function(args, next) {
+  batteryLevel(function (err, res) {
+    if (err) {
+      next(true, null);
+      return;
+    }
+
+    next(false, [res]);
+  });
+}
+
+module.exports = battery;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "http://bit.ly/evac_aggregator",
   "dependencies": {
+    "battery-level": "^1.2.3",
     "byline": "^4.2.1",
     "cheerio-httpcli": "^0.3.2",
     "colors": "^1.1.2",

--- a/test/plugin/in/battery_test.js
+++ b/test/plugin/in/battery_test.js
@@ -1,10 +1,16 @@
 var battery = require('../../../lib/plugin/in/battery.js');
 
 describe('input plugin: battery', function(){
-  it('should received current battery level.', function(done){
-    battery.load({}, function(error, output){
-      output[0].should.be.a('number');
+  if (process.platform == 'darwin') {
+    it('should received current battery level.', function(done){
+      battery.load({}, function(error, output){
+        output[0].should.be.a('number');
+        done();
+      });
+    });
+  } else {
+    it.skip('should received current battery level.', function(done){
       done();
     });
-  });
+  }
 });

--- a/test/plugin/in/battery_test.js
+++ b/test/plugin/in/battery_test.js
@@ -1,0 +1,10 @@
+var battery = require('../../../lib/plugin/in/battery.js');
+
+describe('input plugin: battery', function(){
+  it('should received current battery level.', function(done){
+    battery.load({}, function(error, output){
+      output[0].should.be.a('number');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### 解決したいこと
実行環境のバッテリー残量割合を取得できる入力プラグインを新設します

### Recipe

```yaml
in:
  battery:
filter:
  through:
out:
  stdout:
```

### Output

```
$ node bin/evac recipe/test/test_battery.yaml
0.81
```