### PR TITLE
Updated nodemailer to version 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mysql": "2.9.0",
     "nconf": "0.7.2",
     "node-notifier": "4.3.1",
-    "nodemailer": "1.5.0",
+    "nodemailer": "1.7.0",
     "pushbullet": "1.4.3",
     "request": "2.64.0",
     "step": "0.0.6",


### PR DESCRIPTION
:rocket:

nodemailer just published version 1.7.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 2 commits (ahead by 2, behind by 0).

- [254a402](https://github.com/andris9/Nodemailer/commit/254a4024cdbbb0fb0e6903bd065cb7bfc56805ab): Bumped version to v1.7.0. Replaced hyperquest with needle that should fix most issues with redirects and gzipped content
- [529a8c9](https://github.com/andris9/Nodemailer/commit/529a8c92c2cda2d810410fc6406e07576ddde290): Bumped version to v1.6.0

See the [full diff](https://github.com/andris9/Nodemailer/compare/038ba918cbdbed59a4ef519c18527438b0019f4c...254a4024cdbbb0fb0e6903bd065cb7bfc56805ab).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>