### PR TITLE
GoogleAnalyticsプラグイン機能追加

### DIFF
--- a/lib/plugin/in/googleanalytics.js
+++ b/lib/plugin/in/googleanalytics.js
@@ -1,5 +1,6 @@
 var gaAnalytics = require("ga-analytics"),
-    moment = require("moment");
+    moment = require("moment"),
+    format = require('string-format');
 
 var googleAnalytics = {};
 
@@ -17,7 +18,20 @@ googleAnalytics.load = function(args, next) {
       return;
     }
 
-    outputs.push(res.totalsForAllResults[args.metrics]);
+    if (args.results == "rows") {
+      outputs = res.rows.map(function(val) {
+        var passed = [args.format].concat(val);
+        return format.apply({}, passed);
+      });
+
+      if (args.limit) {
+        outputs = outputs.slice(0, args.limit);
+      }
+
+    } else {
+      outputs.push(res.totalsForAllResults[args.metrics]);
+    }
+
     next(false, outputs);
   });
 };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "pushbullet": "1.4.3",
     "request": "2.67.0",
     "step": "0.0.6",
+    "string-format": "^0.5.0",
     "tunnel-ssh": "^2.0.0",
     "twitter": "^1.2.5",
     "underscore": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "homepage": "http://bit.ly/evac_aggregator",
   "dependencies": {
-    "battery-level": "2.0.0",
     "byline": "4.2.1",
     "cheerio-httpcli": "0.3.8",
     "colors": "1.1.2",


### PR DESCRIPTION
### 解決したいこと
- 直近X日以内の閲覧数の多いURLを抽出しfilterプラグインやoutputプラグインに渡せる様にします

### レシピ例

```json
{
  "in": {
    "googleanalytics": {
      "metrics": "ga:pageviews",
      "dimensions": "ga:pagePath",
      "sort": "-ga:pageviews",
      "clientId": "xxxxx.apps.googleusercontent.com",
      "serviceEmail": "xxxxx@developer.gserviceaccount.com",
      "key": "/home/hideack/key.pem",
      "ids": "ga:xxxxxxx",
      "timeago": {
        "period": "days",
        "ago": 1
      },
      "format":"{0} = {1}PV",
      "limit": 5,
      "results": "rows"
    }
  },
```
