### PR TITLE
ツイート中の改行コード置換処理追加

### DIFF
--- a/lib/plugin/in/twitter.js
+++ b/lib/plugin/in/twitter.js
@@ -41,7 +41,7 @@ twitter.load = function(args, next) {
 
             if (args.format) {
               passedTweet = args.format;
-              passedTweet = passedTweet.replace(/__tweet__/g, tweet.text.replace("\n", ""));
+              passedTweet = passedTweet.replace(/__tweet__/g, tweet.text.replace(/[\n\r]/g, ""));
               passedTweet = passedTweet.replace(/__screen_name__/g, tweet.user.screen_name);
             } else {
               passedTweet = tweet.text;


### PR DESCRIPTION
### 解決したいこと
- twitter入力プラグインで渡されるツイート中の改行コードの除去が行えていなかったので修正する