### PR TITLE
RSSプラグインの新規エントリ判定を直す

### DIFF
--- a/lib/plugin/in/rss.js
+++ b/lib/plugin/in/rss.js
@@ -22,11 +22,8 @@ rss.load = function(args, next) {
     if (err) {
       lastUpdate = 0;
     } else {
-      lastUpdate = moment(data);
+      lastUpdate = moment(new Date(data));
     }
-
-    console.log(data);
-    console.log("===>" + lastUpdate);
 
     mkdir(cacheDir, function(err) {
       var responseArticles = [];
@@ -43,6 +40,10 @@ rss.load = function(args, next) {
           while (item = stream.read()) {
             //({description: articleBody, link: item.link, date: item.date};
             articleBody = item.description.replace(/(<([^>]+)>)/ig,"").replace(/[\n\r]/g,"");
+
+            if (moment(new Date(item.date)).diff(lastUpdate) <= 0) {
+              continue;
+            }
 
             if (args.format) {
               var formatDescription = args.format;

--- a/lib/plugin/in/rss.js
+++ b/lib/plugin/in/rss.js
@@ -2,6 +2,7 @@ var parser = require('feedparser'),
     request = require('request'),
     fs = require('fs'),
     mkdir = require('mkdirp'),
+    moment = require('moment'),
     crypto = require('crypto');
 
 var rss = {};
@@ -14,59 +15,59 @@ rss.load = function(args, next) {
   var articles = [];
   var cacheDir = process.env.HOME + "/.evac/rss/" + md5(args.url);
 
-  mkdir(cacheDir, function(err) {
-    var responseArticles = [];
 
-    request(args.url)
-      .pipe(new parser())
-      .on('error', function(error) {
-        next(error, "request error.");
-      })
-      .on('readable', function () {
-        var stream = this, item;
+  fs.readFile(cacheDir + "/publish-date", "utf8", function(err, data) {
+    var lastUpdate;
 
-        while (item = stream.read()) {
-          articleBody = item.description.replace(/(<([^>]+)>)/ig,"").replace(/[\n\r]/g,"");
-          articles.push({description: articleBody, link: item.link});
-        }
+    if (err) {
+      lastUpdate = 0;
+    } else {
+      lastUpdate = moment(data);
+    }
 
-        for (var i=0; i<articles.length; i++) {
-          var title = articles[i].title;
-          var description = articles[i].description;
-          var link = articles[i].link;
+    console.log(data);
+    console.log("===>" + lastUpdate);
 
-          if (args.uniqueness) {
-            var regexp = new RegExp(args.uniqueness);
+    mkdir(cacheDir, function(err) {
+      var responseArticles = [];
+      var lastDate = "";
 
-            if (description.match(regexp) == null) {
-              articleHash = md5(description);
-            } else {
-              articleHash = md5(description.match(regexp)[0]);
-            }
-          } else {
-            articleHash = md5(description);
-          }
+      request(args.url)
+        .pipe(new parser())
+        .on('error', function(error) {
+          next(error, "request error.");
+        })
+        .on('readable', function () {
+          var stream = this, item;
 
-          if((!fs.existsSync(cacheDir + "/" + articleHash)) || args.forceParse) {
-            fs.writeFileSync(cacheDir + "/" + articleHash, "1");
+          while (item = stream.read()) {
+            //({description: articleBody, link: item.link, date: item.date};
+            articleBody = item.description.replace(/(<([^>]+)>)/ig,"").replace(/[\n\r]/g,"");
 
             if (args.format) {
               var formatDescription = args.format;
-              formatDescription = formatDescription.replace("__description__", description);
-              formatDescription = formatDescription.replace("__link__", link);
-
-              responseArticles.push(formatDescription);
+              formatDescription = formatDescription.replace("__description__", articleBody);
+              formatDescription = formatDescription.replace("__link__", item.link);
             } else {
-              responseArticles.push(description);
+              formatDescription = articleBody;
+            }
+
+            articles.push(formatDescription);
+
+            if (lastDate == "") {
+              lastDate = item.date;
             }
           }
-        }
-      })
-      .on('finish', function(){
-        next(false, responseArticles);
-      });
-  });
+        })
+        .on('finish', function(){
+          if (articles.length > 0) {
+            fs.writeFileSync(cacheDir + "/publish-date", lastDate);
+          }
 
+          next(false, articles);
+        });
+    });
+  });
 }
 
 module.exports = rss;

--- a/test/plugin/in/rss_test.js
+++ b/test/plugin/in/rss_test.js
@@ -19,6 +19,7 @@ describe('input plugin: rss', function(){
         <description>&lt;small&gt;テスト本文(HTMLタグ付き)&lt;/small&gt;</description>
         <title>テストタイトル</title>
         <guid isPermaLink="false">7c7efc1ada6c9342febc5302505e7eb076b4f93f</guid>
+        <pubDate>Sat, 24 Sep 2016 23:30:00 +0900</pubDate>
       </item>
       </channel>
     </rss>
@@ -28,7 +29,7 @@ describe('input plugin: rss', function(){
     nock("http://test.com").get('/rss').reply(200, testFeedWithHtmlTag);
 
     var bufferDir = process.env.HOME + "/.evac/rss/ab25712843b6066950e54871337b229a";
-    var bufferFile = bufferDir + '/4f00f0dbefd09f4914dea2765839f3f9';
+    var bufferFile = bufferDir + '/publish-date';
 
     fs.exists(bufferFile, function(exists) {
       if (exists) {


### PR DESCRIPTION
### 解決したいこと
- 新規エントリ判定がファイルベースのフラグで何故か実装されていたのでこれを最終エントリの発行日時ベースによる判定に修正します
